### PR TITLE
Refactor service to cache the repository information on a schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ hs_err_pid*
 replay_pid*
 
 .idea
+.vscode
 HELP.md
 
 target

--- a/src/main/java/companieshouse/gov/uk/githubapi/GithubapiApplication.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/GithubapiApplication.java
@@ -2,12 +2,18 @@ package companieshouse.gov.uk.githubapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+
+import companieshouse.gov.uk.githubapi.scheduled.FetchGithubRepositories;
 
 @SpringBootApplication
 public class GithubapiApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(GithubapiApplication.class, args);
+		final ApplicationContext context = SpringApplication.run(GithubapiApplication.class, args);
+		final FetchGithubRepositories fetchGithubRepositories = context.getBean(FetchGithubRepositories.class);
+
+		fetchGithubRepositories.populateRepositoryCache();
 	}
 
 }

--- a/src/main/java/companieshouse/gov/uk/githubapi/config/EnableRetryConfiguration.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/config/EnableRetryConfiguration.java
@@ -1,0 +1,15 @@
+package companieshouse.gov.uk.githubapi.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+
+@ConditionalOnProperty(
+    value = "app.retry.enable", havingValue = "true", matchIfMissing = true
+)
+@Configuration
+@EnableRetry
+public class EnableRetryConfiguration {
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/config/SchedulingConfiguration.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/config/SchedulingConfiguration.java
@@ -1,0 +1,14 @@
+package companieshouse.gov.uk.githubapi.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@ConditionalOnProperty(
+    value = "app.scheduling.enable", havingValue = "true", matchIfMissing = true
+)
+@Configuration
+@EnableScheduling
+public class SchedulingConfiguration {
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/config/WebConfig.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/config/WebConfig.java
@@ -1,25 +1,28 @@
 package companieshouse.gov.uk.githubapi.config;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.client.RestOperations;
 
 @Configuration
 @EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
 
-    private String token = "";
+    @Bean
+    public RestOperations restOperations(final RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+            .build();
+    }
 
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
-        return restTemplateBuilder.additionalInterceptors((request, body, execution) -> {
-            request.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer "+token);
-            return execution.execute(request, body);
-        }).build();
+    public DocumentBuilderFactory documentBuilderFactory() {
+        return DocumentBuilderFactory.newInstance();
     }
 
     @Override

--- a/src/main/java/companieshouse/gov/uk/githubapi/controller/GitHubApiController.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/controller/GitHubApiController.java
@@ -1,42 +1,23 @@
 package companieshouse.gov.uk.githubapi.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import companieshouse.gov.uk.githubapi.dao.GitHubAppDataRepository;
-import companieshouse.gov.uk.githubapi.dao.GitHubRepositoryRepository;
-import companieshouse.gov.uk.githubapi.model.GitHubAppData;
-import companieshouse.gov.uk.githubapi.model.GitHubRepository;
-import companieshouse.gov.uk.githubapi.model.GitHubSearchResponse;
-import companieshouse.gov.uk.githubapi.model.GitHubTree;
-import companieshouse.gov.uk.githubapi.model.GitHubTreeResponse;
-import java.io.IOException;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.json.JsonParser;
-import org.springframework.boot.json.JsonParserFactory;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import companieshouse.gov.uk.githubapi.model.GitHubAppData;
+import companieshouse.gov.uk.githubapi.scheduled.FetchGithubRepositories;
+import companieshouse.gov.uk.githubapi.service.AppDataService;
 
 @Controller
 @RequestMapping
@@ -44,195 +25,44 @@ public class GitHubApiController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GitHubApiController.class);
 
-    private final GitHubRepositoryRepository gitHubRepositoryRepository;
-
-    private final GitHubAppDataRepository gitHubAppDataRepository;
-
-    private final RestTemplate restTemplate;
+    private final AppDataService appDataService;
+    private final FetchGithubRepositories fetchGithubRepositories;
 
 
     @Autowired
-    public GitHubApiController(GitHubRepositoryRepository gitHubRepositoryRepository,
-            GitHubAppDataRepository gitHubAppDataRepository, RestTemplate restTemplate) {
-        this.gitHubRepositoryRepository = gitHubRepositoryRepository;
-        this.gitHubAppDataRepository = gitHubAppDataRepository;
-        this.restTemplate = restTemplate;
+    public GitHubApiController(final AppDataService appDataService, final FetchGithubRepositories fetchGithubRepositories) {
+        this.appDataService = appDataService;
+        this.fetchGithubRepositories = fetchGithubRepositories;
     }
 
     @GetMapping("/")
     public String getGitHubAppData(Model model) {
-        List<GitHubAppData> appDataList = gitHubAppDataRepository.findAll();
-        appDataList.sort(Comparator.comparing(GitHubAppData::getId)); // Sort by id alphabetically
+        LOGGER.debug("Loading app data");
+        final List<GitHubAppData> appDataList = new ArrayList<>(appDataService.loadAppData());
+        appDataList.sort(Comparator.comparing(GitHubAppData::id)); // Sort by id alphabetically
         model.addAttribute("appDataList", appDataList);
+        LOGGER.info("Index loaded");
         return "index";
     }
 
 
+    @GetMapping("/get-data")
+    public String getData(Model model)  {
+        List<GitHubAppData> list = appDataService.loadAppData();
+        model.addAttribute("repos", list);
+        return "repos";
+    }
 
     //TODO cron instead of endpoint
     @GetMapping("/populate-repo-data")
     public ResponseEntity<String> getGitHubApiResponse() throws JsonProcessingException {
-
-        boolean hasNext = true;
-        List<GitHubRepository> repoList = new ArrayList<>();
-        int perPage = 100;
-        int page = 0;
-
-        while (hasNext) {
-            page++;
-            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl("https://api.github.com/search/repositories")
-                    .queryParam("q", "user:companieshouse+language:java")
-                    .queryParam("page", page)
-                    .queryParam("per_page", perPage);
-            ResponseEntity<GitHubSearchResponse> response = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, null, GitHubSearchResponse.class);
-            GitHubSearchResponse searchResponse = response.getBody();
-            repoList.addAll(processGitHubSearchResponse(searchResponse));
-            HttpHeaders httpHeaders = response.getHeaders();
-            List<String> list = httpHeaders.get("Link");
-            Pattern pattern = Pattern.compile("rel=\"Next\"", Pattern.CASE_INSENSITIVE);
-            StringBuilder stringBuilder = new StringBuilder();
-            for (String link: list){
-                stringBuilder.append(link);
-            }
-            Matcher matcher = pattern.matcher(stringBuilder.toString());
-            hasNext = matcher.find();
+        if (fetchGithubRepositories.isRunning()) {
+            return ResponseEntity.status(503).body("Already in progress.");
         }
-        gitHubRepositoryRepository.deleteAll();
-        gitHubRepositoryRepository.saveAll(repoList);
-//<https://api.github.com/search/repositories?q=user%3Acompanieshouse+language%3Ajava&per_page=10&page=2>; rel="next", <https://api.github.com/search/repositories?q=user%3Acompanieshouse+language%3Ajava&per_page=10&page=20>; rel="last"
 
-        populateAppData(repoList);
-
+        fetchGithubRepositories.populateRepositoryCache();
+        
         return ResponseEntity.ok("");
     }
 
-
-    public ResponseEntity<String> populateAppData(List<GitHubRepository> repoList) throws JsonProcessingException {
-        AtomicInteger atomicInteger = new AtomicInteger();
-    repoList.forEach(
-        e -> {
-          atomicInteger.getAndIncrement();
-          GitHubAppData gitHubAppData = new GitHubAppData();
-          gitHubAppData.setName(e.getName());
-          if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("Processing {} : {}", atomicInteger, e.getName());
-          }
-          String url =
-              e.getTreesUrl().substring(0, e.getTreesUrl().length() - 6)
-                  + "/"
-                  + e.getDefaultBranch();
-          GitHubTreeResponse treeResponse =
-              restTemplate.getForObject(url, GitHubTreeResponse.class);
-
-          if (treeResponse != null && treeResponse.getTree() != null) {
-            for (GitHubTree tree : treeResponse.getTree()) {
-              if ("pom.xml".equals(tree.getPath())) {
-                // System.out.println(tree.getUrl());
-                String jsonString = restTemplate.getForObject(tree.getUrl(), String.class);
-                JsonParser jsonParser = JsonParserFactory.getJsonParser();
-                Object jsonObject = jsonParser.parseMap(jsonString);
-                String content = "";
-                // Extract the content field from the JSON object
-                if (jsonObject instanceof Map) {
-                  Map<String, Object> jsonMap = (Map<String, Object>) jsonObject;
-                  content = (String) jsonMap.get("content");
-                }
-                String cleanContent = content.replaceAll("[^A-Za-z0-9+/=]", "");
-
-                byte[] decodedBytes = Base64.getDecoder().decode(cleanContent);
-
-                // Convert byte array to String
-                String decodedXml = new String(decodedBytes, StandardCharsets.UTF_8);
-                gitHubAppData.setSpringbootversion(getSpringBootVersion(decodedXml));
-                gitHubAppDataRepository.save(gitHubAppData);
-              }
-            }
-          }
-          // sleep for two seconds
-          try {
-            Thread.sleep(2000);
-          } catch (InterruptedException ex) {
-            LOGGER.error("Error while sleeping", ex);
-          }
-        });
-        return ResponseEntity.ok("");
-    }
-
-    private static List<GitHubRepository> processGitHubSearchResponse(GitHubSearchResponse searchResponse) {
-        List<GitHubRepository> resultList = new ArrayList<>();
-        for (GitHubRepository repository : searchResponse.getRepositories()) {
-            resultList.add(repository);
-        }
-        return resultList;
-    }
-
-    public String getSpringBootVersion(String pomString)  {
-        try {
-            // Create a DocumentBuilder
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
-
-            InputSource inputSource = new InputSource(new StringReader(pomString));
-
-            // Parse the XML and obtain the Document
-            Document document = builder.parse(inputSource);
-
-            // Find the <properties> element
-            Element root = document.getDocumentElement();
-            NodeList propertiesList = root.getElementsByTagName("properties");
-            Element properties = (Element) propertiesList.item(0);
-
-            // Find the spring boot version
-            String springBootVersion = getProperty(properties, "spring-boot.version");
-            if (springBootVersion == null) {
-                springBootVersion = getProperty(properties, "spring.boot.version");
-            }
-            if (springBootVersion == null) {
-                springBootVersion = getProperty(properties, "spring-boot-dependencies.version");
-            }
-            if (springBootVersion == null) {
-                springBootVersion = getProperty(properties, "version.spring.boot");
-            }
-            if (springBootVersion == null){
-                springBootVersion = getProperty(properties, "spring-framework.version");
-                if (springBootVersion == null) {
-                  springBootVersion = getProperty(properties, "spring.framework.version");
-                }
-                if (springBootVersion != null){
-                    springBootVersion = "Uses native Spring version "+springBootVersion;
-                }
-            }
-
-            if (springBootVersion == null) {
-                NodeList parentList = root.getElementsByTagName("parent");
-                Element parent = (Element) parentList.item(0);
-                String artifactId = getProperty(parent, "artifactId");
-                if (artifactId != null && artifactId.equals("spring-boot-starter-parent")) {
-                    springBootVersion = getProperty(parent, "version");
-                } else if (artifactId != null && artifactId.equals("companies-house-parent")) {
-                    springBootVersion = "Uses companies-house-parent pom, no Spring version detected";
-                } else if(artifactId != null){
-                    springBootVersion = "Uses parent pom of "+artifactId;
-                }
-            }
-            if (springBootVersion == null){
-                springBootVersion = "No Spring detected";
-            }
-            return springBootVersion;
-        } catch (ParserConfigurationException | IOException | SAXException e) {
-            LOGGER.error("Error processing data to retrieve Spring boot version", e);
-
-        }
-        return null;
-    }
-    private String getProperty(Element properties, String propertyName) {
-        if (properties != null) {
-          NodeList propertyList = properties.getElementsByTagName(propertyName);
-          if (propertyList.getLength() > 0) {
-            Element property = (Element) propertyList.item(0);
-            return property.getTextContent();
-          }
-        }
-        return null;
-    }
 }

--- a/src/main/java/companieshouse/gov/uk/githubapi/controller/LoadSupportDataController.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/controller/LoadSupportDataController.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestOperations;
 
 @Controller
 @RequestMapping
@@ -20,11 +20,11 @@ public class LoadSupportDataController {
     @Autowired
     private final SupportDataService supportDataService;
 
-    private final RestTemplate restTemplate;
+    private final RestOperations restTemplate;
 
     private final ObjectMapper objectMapper;
 
-    public LoadSupportDataController(SupportDataService supportDataService, RestTemplate restTemplate,
+    public LoadSupportDataController(SupportDataService supportDataService, RestOperations restTemplate,
             ObjectMapper objectMapper){
 
         this.supportDataService = supportDataService;

--- a/src/main/java/companieshouse/gov/uk/githubapi/dao/GitHubAppDataRepository.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/dao/GitHubAppDataRepository.java
@@ -1,8 +1,0 @@
-package companieshouse.gov.uk.githubapi.dao;
-
-import companieshouse.gov.uk.githubapi.model.GitHubAppData;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface GitHubAppDataRepository extends MongoRepository<GitHubAppData, String>  {
-
-}

--- a/src/main/java/companieshouse/gov/uk/githubapi/dao/GitHubRepoRepository.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/dao/GitHubRepoRepository.java
@@ -1,0 +1,9 @@
+package companieshouse.gov.uk.githubapi.dao;
+
+import companieshouse.gov.uk.githubapi.model.GitHubRepositoryDao;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface GitHubRepoRepository extends MongoRepository<GitHubRepositoryDao, String>  {
+
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/dao/GitHubRepositoryRepository.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/dao/GitHubRepositoryRepository.java
@@ -1,8 +1,0 @@
-package companieshouse.gov.uk.githubapi.dao;
-
-import companieshouse.gov.uk.githubapi.model.GitHubRepository;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface GitHubRepositoryRepository extends MongoRepository<GitHubRepository, String> {
-
-}

--- a/src/main/java/companieshouse/gov/uk/githubapi/exception/GithubApiCallErrorException.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/exception/GithubApiCallErrorException.java
@@ -1,0 +1,9 @@
+package companieshouse.gov.uk.githubapi.exception;
+
+public class GithubApiCallErrorException extends RuntimeException {
+
+    public GithubApiCallErrorException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/exception/PoolyFormattedDependenciesFileException.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/exception/PoolyFormattedDependenciesFileException.java
@@ -1,0 +1,13 @@
+package companieshouse.gov.uk.githubapi.exception;
+
+public class PoolyFormattedDependenciesFileException extends RuntimeException {
+    
+
+    public PoolyFormattedDependenciesFileException(final String message) {
+        super(message);
+    }
+
+    public PoolyFormattedDependenciesFileException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/DependencySpec.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/DependencySpec.java
@@ -1,0 +1,5 @@
+package companieshouse.gov.uk.githubapi.model;
+
+import java.util.Optional;
+
+public record DependencySpec(String groupId, String artifactId, Optional<String> version) {}

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubAppData.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubAppData.java
@@ -1,38 +1,8 @@
 package companieshouse.gov.uk.githubapi.model;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document
-public class GitHubAppData {
-    @Id
-    private String name;
-    private String springbootversion;
-
-    public String getId() {
-        return name;
-    }
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getSpringBootVersion() {
-        return springbootversion;
-    }
-
-    public void setSpringbootversion(String springbootversion) {
-        this.springbootversion = springbootversion;
-    }
-
-    @Override
-    public String toString() {
-        return "GitHubAppData{" +
-                "name='" + name + '\'' +
-                ", springbootversion='" + springbootversion + '\'' +
-                '}';
-    }
-}
+public record GitHubAppData(
+    String id,
+    String name,
+    String springBootVersion
+) {}

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubLeaf.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubLeaf.java
@@ -1,0 +1,10 @@
+package companieshouse.gov.uk.githubapi.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GitHubLeaf(
+    String content
+) {
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubRepository.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubRepository.java
@@ -2,53 +2,10 @@ package companieshouse.gov.uk.githubapi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Document("github_repository")
-public class GitHubRepository {
-
-    @JsonProperty("name")
-    private String name;
-
-    @JsonProperty("trees_url")
-    private String treesUrl;
-
-    @JsonProperty("default_branch")
-    private String defaultBranch;
-
-    // Getters and setters
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getTreesUrl() {
-        return treesUrl;
-    }
-
-    public void setTreesUrl(String treesUrl) {
-        this.treesUrl = treesUrl;
-    }
-
-    public String getDefaultBranch() {
-        return defaultBranch;
-    }
-
-    public void setDefaultBranch(String defaultBranch) {
-        this.defaultBranch = defaultBranch;
-    }
-
-    @Override
-    public String toString() {
-        return "GitHubRepository{" +
-                "name='" + name + '\'' +
-                ", treesUrl='" + treesUrl + '\'' +
-                ", defaultBranch='" + defaultBranch + '\'' +
-                '}';
-    }
-}
+public record GitHubRepository(
+    @JsonProperty("name") String name,
+    @JsonProperty("trees_url") String treesUrl,
+    @JsonProperty("default_branch") String defaultBranch
+) {}

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubRepositoryDao.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubRepositoryDao.java
@@ -1,0 +1,67 @@
+package companieshouse.gov.uk.githubapi.model;
+
+import java.util.Map;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document
+public class GitHubRepositoryDao {
+    @Id
+    private final String repoName;
+    private final Map<String, String> dependencies;
+
+
+    public GitHubRepositoryDao(final String repoName, final Map<String, String> dependencies) {
+        this.repoName = repoName;
+        this.dependencies = dependencies;
+    }
+
+    public String getRepoName() {
+        return repoName;
+    }
+
+    public Map<String, String> getDependencies() {
+        return Map.copyOf(dependencies);
+    }
+
+
+    @Override
+    public String toString() {
+        return String.format("GithubRepositoryDao[repoName=%, dependencies=%s]", repoName, dependencies);
+    }
+
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((repoName == null) ? 0 : repoName.hashCode());
+        result = prime * result + ((dependencies == null) ? 0 : dependencies.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        GitHubRepositoryDao other = (GitHubRepositoryDao) obj;
+        if (repoName == null) {
+            if (other.repoName != null)
+                return false;
+        } else if (!repoName.equals(other.repoName))
+            return false;
+        if (dependencies == null) {
+            if (other.dependencies != null)
+                return false;
+        } else if (!dependencies.equals(other.dependencies))
+            return false;
+        return true;
+    }
+
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubSearchResponse.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubSearchResponse.java
@@ -4,54 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
-import org.springframework.data.annotation.Id;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GitHubSearchResponse {
-
-    @Id
-    private String id;
-
-    @JsonProperty("total_count")
-    private int totalCount;
-
-    @JsonProperty("incomplete_results")
-    private boolean incompleteResults;
-
-    @JsonProperty("items")
-    private List<GitHubRepository> repositories;
-
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public int getTotalCount() {
-        return totalCount;
-    }
-
-    public void setTotalCount(int totalCount) {
-        this.totalCount = totalCount;
-    }
-
-    public boolean isIncompleteResults() {
-        return incompleteResults;
-    }
-
-    public void setIncompleteResults(boolean incompleteResults) {
-        this.incompleteResults = incompleteResults;
-    }
-
-    public List<GitHubRepository> getRepositories() {
-        return repositories;
-    }
-
-    public void setRepositories(List<GitHubRepository> repositories) {
-        this.repositories = repositories;
-    }
-}
+public record GitHubSearchResponse(
+    String id,
+    @JsonProperty("total_count") int totalCount,
+    @JsonProperty("incomplete_results") boolean incompleteResults,
+    @JsonProperty("items") List<GitHubRepository> repositories
+) {}
 

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubTree.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubTree.java
@@ -2,65 +2,11 @@ package companieshouse.gov.uk.githubapi.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class GitHubTree {
-    private String path;
-    private String mode;
-    private String type;
-    private String url;
-
-    @JsonProperty("sha")
-    private String treeSha;
-
-    public String getPath() {
-        return path;
-    }
-
-    public void setPath(String path) {
-        this.path = path;
-    }
-
-    public String getMode() {
-        return mode;
-    }
-
-    public void setMode(String mode) {
-        this.mode = mode;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public void setUrl(String url) {
-        this.url = url;
-    }
-
-    public String getTreeSha() {
-        return treeSha;
-    }
-
-    public void setTreeSha(String treeSha) {
-        this.treeSha = treeSha;
-    }
-
-    @Override
-    public String
-    toString() {
-        return "GitHubTree{" +
-                "path='" + path + '\'' +
-                ", mode='" + mode + '\'' +
-                ", type='" + type + '\'' +
-                ", url='" + url + '\'' +
-                ", treeSha='" + treeSha + '\'' +
-                '}';
-    }
-}
+public record GitHubTree(
+    String path,
+    String mode,
+    String type,
+    String url,
+    @JsonProperty("sha") String treeSha
+) {}
 

--- a/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubTreeResponse.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/model/GitHubTreeResponse.java
@@ -6,16 +6,4 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class GitHubTreeResponse {
-
-    @JsonProperty("tree")
-    private List<GitHubTree> tree;
-
-    public List<GitHubTree> getTree() {
-        return tree;
-    }
-
-    public void setTree(List<GitHubTree> tree) {
-        this.tree = tree;
-    }
-}
+public record GitHubTreeResponse(@JsonProperty("tree") List<GitHubTree> tree) {}

--- a/src/main/java/companieshouse/gov/uk/githubapi/scheduled/FetchGithubRepositories.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/scheduled/FetchGithubRepositories.java
@@ -1,0 +1,67 @@
+package companieshouse.gov.uk.githubapi.scheduled;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import companieshouse.gov.uk.githubapi.dao.GitHubRepoRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubRepositoryDao;
+import companieshouse.gov.uk.githubapi.service.GithubRepositoryService;
+
+@Component
+public class FetchGithubRepositories {
+
+    private static final String POPULATION_CRON_EXPRESSION = "0 0/10 6-20 * * Mon-Fri";
+    private static final Logger LOGGER = LoggerFactory.getLogger(FetchGithubRepositories.class);
+
+    private final GithubRepositoryService githubRepositoryService;
+    private final GitHubRepoRepository gitHubRepoRepository;
+    private final ScheduledJobState scheduledJobState;
+
+    @Autowired
+    public FetchGithubRepositories(final GithubRepositoryService githubRepositoryService, final GitHubRepoRepository gitHubRepoRepository) {
+        this(githubRepositoryService, gitHubRepoRepository, new ScheduledJobState());
+    }
+
+    public FetchGithubRepositories(final GithubRepositoryService githubRepositoryService, final GitHubRepoRepository gitHubRepoRepository, final ScheduledJobState scheduledJobState) {
+        this.githubRepositoryService = githubRepositoryService;
+        this.gitHubRepoRepository =  gitHubRepoRepository;
+        this.scheduledJobState = scheduledJobState;
+    }
+
+    @Scheduled(cron = POPULATION_CRON_EXPRESSION)
+    public void populateRepositoryCache() {
+        if (isRunning()) {
+            LOGGER.warn("Already a task updating cache in progress.");
+
+            return;
+        }
+
+        scheduledJobState.updateRunningState(true);
+        LOGGER.info("Populating the cache with latest repository information");
+
+        final List<GitHubRepository> repositories = githubRepositoryService.listJavaRepositories();
+
+        repositories
+            .parallelStream()
+            .forEach(repository -> {
+                LOGGER.debug("Updating dependencies of {}", repository.name());
+                final Map<String, String> dependencies = githubRepositoryService.loadDependencies(repository);
+
+                gitHubRepoRepository.save(new GitHubRepositoryDao(repository.name(), dependencies));
+            });
+        scheduledJobState.updateRunningState(false);
+
+        LOGGER.info("Cache population complete");
+    }
+
+    public boolean isRunning() {
+        return scheduledJobState.isRunning();
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/scheduled/ScheduledJobState.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/scheduled/ScheduledJobState.java
@@ -1,0 +1,19 @@
+package companieshouse.gov.uk.githubapi.scheduled;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ScheduledJobState {
+    private final AtomicBoolean state;
+
+    public ScheduledJobState() {
+        state = new AtomicBoolean(false);
+    }
+
+    public void updateRunningState(final boolean newState) {
+        state.set(newState);
+    }
+
+    public boolean isRunning() {
+        return state.get();
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/AppDataService.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/AppDataService.java
@@ -1,0 +1,66 @@
+package companieshouse.gov.uk.githubapi.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import companieshouse.gov.uk.githubapi.dao.GitHubRepoRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubAppData;
+import companieshouse.gov.uk.githubapi.model.GitHubRepositoryDao;
+
+@Service
+public class AppDataService {
+
+    private static final String SPRING_BOOT_DEPENDENCY_PREFIX = "spring-boot";
+    private static final String SPRING_FRAMEWORK_DEPENDENCY_PREFIX = "spring-framework";
+    private static final String SPRING_VERSION_NOT_RESOLVED = "No Spring detected";
+    
+    private final GitHubRepoRepository gitHubRepoRepository;
+
+    @Autowired
+    public AppDataService(final GitHubRepoRepository gitHubRepoRepository) {
+        this.gitHubRepoRepository = gitHubRepoRepository;
+    }
+
+    public List<GitHubAppData> loadAppData() {
+        return gitHubRepoRepository.findAll()
+            .parallelStream()
+            .map(this::convertToGitHubAppData)
+            .toList();
+    }
+
+    private GitHubAppData convertToGitHubAppData(final GitHubRepositoryDao repository) {
+        return resolvePossibleSpringBootVersion(repository.getDependencies()).map(
+            springBootVersion -> new GitHubAppData(repository.getRepoName(), repository.getRepoName(), springBootVersion)
+        ).orElseGet(() -> new GitHubAppData(repository.getRepoName(), repository.getRepoName(), SPRING_VERSION_NOT_RESOLVED));
+    }
+
+    private Optional<String> resolvePossibleSpringBootVersion(final Map<String, String> dependencies) {
+        final Optional<String> springBootVersion = resolveDependencyVersion(dependencies, SPRING_BOOT_DEPENDENCY_PREFIX);
+        
+        if (springBootVersion.isPresent()) {
+            return springBootVersion;
+        }
+
+        final Optional<String> springFrameworkVersion = resolveDependencyVersion(dependencies, SPRING_FRAMEWORK_DEPENDENCY_PREFIX)
+            .map(version -> "Uses native Spring version " + version);
+        
+        if (springFrameworkVersion.isPresent()) {
+            return springFrameworkVersion;
+        }
+
+        return resolveDependencyVersion(dependencies, "companies-house-parent")
+            .map(version -> "Uses companies-house-parent pom (version: " + version + "), no Spring version detected");
+    }
+
+    private final Optional<String> resolveDependencyVersion(final Map<String, String> dependencies, final String dependencyPrefix) {
+        return dependencies.entrySet().stream()
+        .filter(dependency -> dependency.getKey().contains(dependencyPrefix))
+        .findAny()
+        .map(Map.Entry::getValue);
+    }
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/GithubApiPaginationService.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/GithubApiPaginationService.java
@@ -1,0 +1,85 @@
+package companieshouse.gov.uk.githubapi.service;
+
+import static companieshouse.gov.uk.githubapi.util.QueryStringUtility.parseQueryString;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+public class GithubApiPaginationService {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(GithubApiPaginationService.class);
+    private static final Pattern NEXT_LINK_PATTERN = Pattern.compile("rel=\"next\"", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern LINK_PATTERN = Pattern.compile("<([^>]+)>", Pattern.DOTALL);
+
+    private GithubApiPaginationService() {}
+
+    public static <T> List<T> paginateResponseFromApi(final Function<Integer, ResponseEntity<T>> pageSupplier) {
+        final List<T> allItems = new ArrayList<>();
+
+        Optional<Integer> page = Optional.of(1);
+
+        while (page.isPresent()) {
+            final int pageNumber = page.get();
+            LOGGER.debug("Loading page {} of results", pageNumber);
+            
+            final ResponseEntity<T> response = pageSupplier.apply(pageNumber);
+
+            allItems.add(response.getBody());
+
+            final HttpHeaders httpHeaders = response.getHeaders();
+
+            final List<String> linkHeaders = httpHeaders.get("Link");
+            final Stream<String> linkStream = linkHeaders == null ? Stream.empty() : linkHeaders.parallelStream();
+            
+            page = linkStream
+                .flatMap(header -> Arrays.stream(header.split(",")))
+                .filter(link -> NEXT_LINK_PATTERN.matcher(link).find())
+                .map(link -> link.split(";"))
+                .map(linkParts -> Arrays.stream(linkParts).map(String::strip).toArray(String[]::new))
+                .map(linkParts -> linkParts[0])
+                .findFirst()
+                .map(GithubApiPaginationService::getRequestedPageNumber);
+        }
+
+        return allItems;
+
+    }
+
+    private static int getRequestedPageNumber(final String url) {
+        try {
+
+            final Matcher linkMatcher = LINK_PATTERN.matcher(url);
+            
+            if (linkMatcher.matches()) {
+                final String link = linkMatcher.group(1);
+                
+                final URL linkUrl = new URL(link);
+
+                final Map<String, List<String>> queryString = parseQueryString(linkUrl.getQuery());
+
+                if (queryString.containsKey("page")) {
+                    return Integer.parseInt(queryString.get("page").get(0));
+                }
+            }
+        } catch (final MalformedURLException urlException) {
+            throw new RuntimeException(urlException);
+        }
+
+        throw new RuntimeException("Could not determine the page requested");
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/GithubRepositoryService.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/GithubRepositoryService.java
@@ -1,0 +1,101 @@
+package companieshouse.gov.uk.githubapi.service;
+
+
+import static companieshouse.gov.uk.githubapi.service.GithubApiPaginationService.paginateResponseFromApi;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import companieshouse.gov.uk.githubapi.model.GitHubLeaf;
+import companieshouse.gov.uk.githubapi.model.GitHubRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubSearchResponse;
+import companieshouse.gov.uk.githubapi.model.GitHubTreeResponse;
+import companieshouse.gov.uk.githubapi.util.GithubApi;
+
+@Service
+public class GithubRepositoryService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GithubRepositoryService.class);
+    private static final String GITHUB_SEARCH_API_URL = "https://api.github.com/search/repositories";
+    private static final int PAGE_SIZE = 100;
+    private static final String COMPANIES_HOUSE_ORGANISATION_USER_NAME = "companieshouse";
+    private static final String FILTER_QUERY = "user:" + COMPANIES_HOUSE_ORGANISATION_USER_NAME + "+language:java";
+
+    private final GithubApi githubApi;
+    private final MavenDependenciesParsingService mvnDependenciesParsingService;
+
+    @Autowired
+    public GithubRepositoryService(final GithubApi githubApi, final MavenDependenciesParsingService mvnDependenciesParsingService) {
+        this.githubApi = githubApi;
+        this.mvnDependenciesParsingService = mvnDependenciesParsingService;
+    }
+
+    public List<GitHubRepository> listJavaRepositories() {
+        final List<GitHubSearchResponse> searchResponses = paginateResponseFromApi(this::callGithubSearchApiForRepositories);
+
+        LOGGER.debug("Repositories loaded.");
+
+        return searchResponses.parallelStream()
+            .flatMap(searchResponse -> searchResponse.repositories().stream())
+            .toList();
+    }
+
+    public Map<String, String> loadDependencies(final GitHubRepository githubRepository) {
+        final GitHubTreeResponse gitHubTreeResponse = getGithubTreeOfRepository(githubRepository);
+
+        // TODO: When need to process non-maven projects change this bit to handle each repository
+        return gitHubTreeResponse.tree().parallelStream()
+            .filter(tree -> tree.path().strip().equals("pom.xml"))
+            .map(tree -> {
+                LOGGER.debug("Loading POM for {}", githubRepository.name());
+                final String dependenciesFile = loadLeaf(tree.url());
+
+                try {
+                    return Optional.of(mvnDependenciesParsingService.parseDependencies(dependenciesFile));
+                } catch (final Exception saxParseException) {
+                    LOGGER.warn("Could not load {} of repo {}", tree.url(), githubRepository.name(), saxParseException);
+
+                    return Optional.<Map<String, String>>empty();
+                }
+            })
+            .filter(Optional::isPresent)
+            .findFirst()
+            .map(Optional::get)
+            .orElse(Map.of());
+    }
+
+    private String loadLeaf(final String url) {
+        final GitHubLeaf dependenciesFile = githubApi.get(url, GitHubLeaf.class).getBody();
+
+        final String cleanContent = dependenciesFile.content().replaceAll("[^A-Za-z0-9+/=]", "");
+
+        return new String(Base64.getDecoder().decode(cleanContent), StandardCharsets.UTF_8);
+    }
+
+    private GitHubTreeResponse getGithubTreeOfRepository(final GitHubRepository githubRepository) {
+        final String treesUrl = githubRepository.treesUrl();
+        final String normalisedTreesUrl = treesUrl.substring(0, treesUrl.indexOf("{")) + "/" + githubRepository.defaultBranch();
+
+        return githubApi.get(normalisedTreesUrl, GitHubTreeResponse.class).getBody();
+    }
+
+    private ResponseEntity<GitHubSearchResponse> callGithubSearchApiForRepositories(final int page) {
+        final UriComponentsBuilder uriBuilder =  UriComponentsBuilder.fromHttpUrl(GITHUB_SEARCH_API_URL)
+            .queryParam("q", FILTER_QUERY)
+            .queryParam("page", page)
+            .queryParam("per_page", PAGE_SIZE);
+
+        return githubApi.get(uriBuilder.toUriString(), GitHubSearchResponse.class);
+    }
+
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/MavenDependenciesParsingService.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/MavenDependenciesParsingService.java
@@ -1,0 +1,49 @@
+package companieshouse.gov.uk.githubapi.service;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import companieshouse.gov.uk.githubapi.exception.PoolyFormattedDependenciesFileException;
+import companieshouse.gov.uk.githubapi.service.mvn.ParseRule;
+
+@Component
+public class MavenDependenciesParsingService {
+
+    private final List<ParseRule> parseRules;
+    private final DocumentBuilderFactory documentBuilderFactory;
+
+    @Autowired
+    public MavenDependenciesParsingService(final List<ParseRule> parseRules, final DocumentBuilderFactory documentBuilderFactory) {
+        this.parseRules = parseRules;
+        this.documentBuilderFactory = documentBuilderFactory;
+    }
+
+    public Map<String, String> parseDependencies(final String dependenciesFile) {
+        try {
+            final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            final InputSource inputSource = new InputSource(new StringReader(dependenciesFile));
+
+            final Document document = documentBuilder.parse(inputSource);
+
+            return parseRules.stream()
+                .flatMap(rule -> rule.run(document).entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        } catch (final ParserConfigurationException|IOException|SAXException parserConfigurationException) {
+            throw new PoolyFormattedDependenciesFileException("Could not parse POM", parserConfigurationException);
+        }
+    }
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/DependencyManagementParseRule.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/DependencyManagementParseRule.java
@@ -1,0 +1,38 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import static companieshouse.gov.uk.githubapi.util.XmlUtils.loadDependencySpec;
+import static companieshouse.gov.uk.githubapi.util.XmlUtils.getElementsByTagName;
+import static companieshouse.gov.uk.githubapi.util.XmlUtils.getNodeStream;
+import static companieshouse.gov.uk.githubapi.util.NameUtils.normaliseName;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class DependencyManagementParseRule implements ParseRule {
+
+    @Override
+    public Map<String, String> run(final Document xmlDocument) {
+        
+        final Element root = xmlDocument.getDocumentElement();
+        final Optional<Element> dependencyManagement = getElementsByTagName(root, "dependencyManagement");
+
+        return dependencyManagement.map(
+            element -> {
+                final NodeList children = element.getElementsByTagName("dependencies");
+                final Element dependencies = (Element) children.item(0);
+
+                return getNodeStream(dependencies.getChildNodes(), "dependency")
+                    .map(node -> loadDependencySpec((Element) node))
+                    .filter(spec -> spec.version().isPresent())
+                    .map(spec -> Map.of(normaliseName(spec.artifactId()), spec.version().get()))
+                    .flatMap(map -> map.entrySet().stream())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
+        ).orElseGet(() -> Map.of());
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/ParentVersionParseRule.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/ParentVersionParseRule.java
@@ -1,0 +1,34 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import static companieshouse.gov.uk.githubapi.util.XmlUtils.loadDependencySpec;
+import static companieshouse.gov.uk.githubapi.util.XmlUtils.getElementsByTagName;
+import static companieshouse.gov.uk.githubapi.util.NameUtils.normaliseName;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import companieshouse.gov.uk.githubapi.model.DependencySpec;
+
+@Component
+public class ParentVersionParseRule implements ParseRule {
+
+    @Override
+    public Map<String, String> run(Document xmlDocument) {
+        
+        final Element root = xmlDocument.getDocumentElement();
+        final Optional<Element> parent = getElementsByTagName(root, "parent");
+
+        final Optional<DependencySpec> dependencySpec = loadDependencySpec(parent);
+
+        return dependencySpec
+            .flatMap(spec -> 
+                spec.version()
+                    .map(version -> Map.of(normaliseName(spec.artifactId()), version))
+            ).orElse(Map.of());
+    }
+    
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/ParseRule.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/ParseRule.java
@@ -1,0 +1,10 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import org.w3c.dom.Document;
+
+import java.util.Map;
+
+public interface ParseRule {
+
+    Map<String, String> run(final Document xmlDocument);
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/PropertiesParseRule.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/service/mvn/PropertiesParseRule.java
@@ -1,0 +1,35 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import static companieshouse.gov.uk.githubapi.util.NameUtils.normaliseName;
+import static companieshouse.gov.uk.githubapi.util.XmlUtils.getNodeStream;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+@Component
+public class PropertiesParseRule implements ParseRule {
+
+    @Override
+    public Map<String, String> run(final Document xmlDocument) {
+        
+        // Find the <properties> element
+        final Element root = xmlDocument.getDocumentElement();
+        final NodeList propertiesList = root.getElementsByTagName("properties");
+        final Element properties = (Element) propertiesList.item(0);
+
+        if (properties == null) {
+            return Map.of();
+        }
+
+        return getNodeStream(properties.getChildNodes())
+            .filter(node -> node.getNodeName().toLowerCase().strip().endsWith(".version"))
+            .flatMap(node -> Map.of(normaliseName(node.getNodeName(), "."), node.getTextContent()).entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/util/GithubApi.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/util/GithubApi.java
@@ -1,0 +1,66 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestOperations;
+
+import companieshouse.gov.uk.githubapi.exception.GithubApiCallErrorException;
+
+@Component
+public class GithubApi {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(GithubApi.class);
+
+    private final RestOperations restOperations;
+    private final String githubAuthenticationToken;
+
+    public GithubApi(final RestOperations restOperations, @Value("${github.pat}") final String githubAuthenticationToken) {
+        this.restOperations = restOperations;
+        this.githubAuthenticationToken = githubAuthenticationToken;
+    }
+
+    @Retryable(
+        retryFor = {
+            GithubApiCallErrorException.class,
+            RestClientException.class
+        },
+        backoff = @Backoff(delayExpression = "${app.retry.delay}", multiplierExpression = "${app.retry.multiplier}"),
+        maxAttempts = 5
+    )
+    public <T> ResponseEntity<T> get(
+        final String url,
+        final Class<T> responseClass
+    ) {
+        final HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setBearerAuth(githubAuthenticationToken);
+
+        try {
+            return this.restOperations.exchange(
+                url,
+                HttpMethod.GET,
+                new HttpEntity<>(httpHeaders),
+                responseClass
+            );
+        } catch (final RestClientException restClientException) {
+            if (restClientException instanceof HttpStatusCodeException) {
+                final HttpStatusCodeException httpStatusCodeException = (HttpStatusCodeException) restClientException;
+                LOGGER.warn("API call to {} failed with status {}", url, httpStatusCodeException.getStatusCode());
+
+                throw new GithubApiCallErrorException("Github API Call failed with: " + httpStatusCodeException.getStatusText(), restClientException);
+            } else {
+                LOGGER.warn("Api Call failed: {}", restClientException.getMessage());
+                throw restClientException;
+            }
+        }
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/util/NameUtils.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/util/NameUtils.java
@@ -1,0 +1,36 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class NameUtils {
+    
+    private static final List<String> UNDESIRED_SUFFIXES = List.of(
+        "dependencies",
+        "version"
+    );
+
+    private static final Pattern UNDESIRED_CHARACTERS_PATTERN = Pattern.compile("[^A-Za-z0-9\\-]");
+
+    public static String normaliseName(final String name) {
+        return normaliseName(name, "-");
+    }
+
+    public static String normaliseName(final String name, final String separator) {
+        final String canonicalSeparator = separator.equals(".") ? "\\." : separator;
+
+        final String reversed = StringUtils.reverseDelimited(name, separator.charAt(0));
+
+        final String[] parts = reversed.split(canonicalSeparator, 2);
+
+        final String minusSuffix = UNDESIRED_SUFFIXES.stream()
+            .filter(suffix -> suffix.equals(parts[0]))
+            .map(suffix -> StringUtils.reverseDelimited(parts[1], separator.charAt(0)))
+            .findFirst()
+            .orElse(name);
+        
+        return UNDESIRED_CHARACTERS_PATTERN.matcher(minusSuffix).replaceAll("-");
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/util/QueryStringUtility.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/util/QueryStringUtility.java
@@ -1,0 +1,35 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class QueryStringUtility {
+
+    
+    private QueryStringUtility() {}
+
+    public static Map<String, List<String>> parseQueryString(final String query) {
+        final Map<String, List<String>> parsedQueryString = new HashMap<>();
+
+        // TODO: Tried to use collectors and reducers but nothing seemed to compile
+        // This seems to be the only way to convert the list of query parameters
+        Arrays.stream(query.split("&"))
+            .map(parameter ->  parameter.split("=", 2))
+            .forEach(parameter -> {
+                if (parsedQueryString.containsKey(parameter[0])) {
+                    parsedQueryString.get(parameter[0]).add(parameter[1]);
+                } else {
+                    final List<String> values = new ArrayList<>();
+
+                    values.add(parameter[1]);
+
+                    parsedQueryString.put(parameter[0], values);
+                }
+            });
+
+        return parsedQueryString;
+    }
+}

--- a/src/main/java/companieshouse/gov/uk/githubapi/util/XmlUtils.java
+++ b/src/main/java/companieshouse/gov/uk/githubapi/util/XmlUtils.java
@@ -1,0 +1,60 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import companieshouse.gov.uk.githubapi.exception.PoolyFormattedDependenciesFileException;
+import companieshouse.gov.uk.githubapi.model.DependencySpec;
+
+public final class XmlUtils {
+    
+    private XmlUtils() {}
+
+    public static Optional<DependencySpec> loadDependencySpec(final Optional<Element> element) {
+        return element.map(XmlUtils::loadDependencySpec);
+    }
+
+    public static DependencySpec loadDependencySpec(final Element element) {
+        final NodeList nodeList = element.getChildNodes();
+        
+        final Optional<String> groupId = getChildValue(nodeList, "groupId");
+        final Optional<String> artifactId = getChildValue(nodeList, "artifactId");
+        final Optional<String> version = getChildValue(nodeList, "version");
+
+        return groupId
+            .flatMap(group -> artifactId.map(artifact -> new DependencySpec(group, artifact, version)))
+            .orElseThrow(() -> 
+                new PoolyFormattedDependenciesFileException(
+                    "Dependency missing required parameter: artifactId"
+                )
+            );
+    }
+
+    public static Optional<Element> getElementsByTagName(final Element element, final String tagName) {
+        final NodeList parentNodeList = element.getElementsByTagName(tagName);
+
+        return Optional.ofNullable((Element) parentNodeList.item(0));
+    } 
+
+    public static Stream<Node> getNodeStream(final NodeList nodeList, final String expectedTagName) {
+        return getNodeStream(nodeList)
+            .filter(node -> node.getNodeName().strip().equals(expectedTagName));
+    }
+
+    public static Stream<Node> getNodeStream(final NodeList nodeList) {
+        return IntStream.range(0, nodeList.getLength())
+            .boxed()
+            .map(index -> nodeList.item(index));
+    }
+
+    private static Optional<String> getChildValue(final NodeList childNodes, final String tag) {
+        return getNodeStream(childNodes, tag)
+            .map(Node::getTextContent)
+            .findFirst();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,4 +5,12 @@ spring.data.mongodb.database=testdb
 spring.data.mongodb.username=mongoadmin
 spring.data.mongodb.password=secret
 
+github.pat=${GITHUB_PAT}
 
+app.retry.enable=true
+app.retry.delay=20000
+app.retry.multiplier=3
+
+app.scheduling.enable=true
+
+logging.level.companieshouse=${LOG_LEVEL:INFO}

--- a/src/test/java/companieshouse/gov/uk/githubapi/GithubapiApplicationTests.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/GithubapiApplicationTests.java
@@ -2,8 +2,17 @@ package companieshouse.gov.uk.githubapi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import com.mongodb.client.MongoClient;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+        "github.pat=ghp_123456789012345",
+        "app.scheduling.enable=false",
+        "app.retry.enable=false"
+})
 class GithubapiApplicationTests {
 
 	@Test

--- a/src/test/java/companieshouse/gov/uk/githubapi/configuration/MongoConfiguration.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/configuration/MongoConfiguration.java
@@ -1,0 +1,12 @@
+package companieshouse.gov.uk.githubapi.configuration;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+
+import com.mongodb.client.MongoClient;
+
+@Configuration
+@MockBean(MongoClient.class)
+public class MongoConfiguration {
+    
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/scheduled/FetchGithubRepositoriesTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/scheduled/FetchGithubRepositoriesTest.java
@@ -1,0 +1,116 @@
+package companieshouse.gov.uk.githubapi.scheduled;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import companieshouse.gov.uk.githubapi.dao.GitHubRepoRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubRepositoryDao;
+import companieshouse.gov.uk.githubapi.service.GithubRepositoryService;
+
+@ExtendWith(MockitoExtension.class)
+public class FetchGithubRepositoriesTest {
+
+    @Mock
+    private GithubRepositoryService githubRepositoryServiceMock;
+
+    @Mock
+    private GitHubRepoRepository gitHubRepoRepositoryMock;
+
+    @Mock
+    private ScheduledJobState scheduledJobStateMock;
+
+    @InjectMocks
+    private FetchGithubRepositories fetchGithubRepositories;
+
+    @Captor
+    private ArgumentCaptor<GitHubRepository> gitHubRepositoryArgumentCaptor;
+
+    @Test
+    void testPopulateRepositoryCacheLoadsJavaRepositories() {
+        fetchGithubRepositories.populateRepositoryCache();
+
+        verify(githubRepositoryServiceMock, times(1)).listJavaRepositories();
+    }
+
+    @Test
+    void testPopulateRepositoryCacheLoadsDependenciesOfEachRepository() {
+        List<GitHubRepository> repos = List.of(
+            new GitHubRepository("my-java-library-one", "trees.com", "main"),
+            new GitHubRepository("my-java-library-two", "trees2.com", "master")
+        );
+        when(githubRepositoryServiceMock.listJavaRepositories()).thenReturn(repos);
+
+        fetchGithubRepositories.populateRepositoryCache();
+
+        verify(githubRepositoryServiceMock, times(2)).loadDependencies(gitHubRepositoryArgumentCaptor.capture());
+
+        assertThat(gitHubRepositoryArgumentCaptor.getAllValues()).hasSize(2).containsExactlyInAnyOrderElementsOf(repos);
+    }
+
+    @Test
+    void testPopulateRepositoryCacheAddsTheDependencyInfoToCache() {
+        GitHubRepository repo = new GitHubRepository("my-java-library-one", "trees.com", "main");
+        when(githubRepositoryServiceMock.listJavaRepositories()).thenReturn(List.of(
+                repo
+            )
+        );
+
+        when(githubRepositoryServiceMock.loadDependencies(repo)).thenReturn(
+            Map.of("spring", "3.0.0", "jacoco", "0.8.0")
+        );
+
+        fetchGithubRepositories.populateRepositoryCache();
+
+        verify(gitHubRepoRepositoryMock, times(1)).save(new GitHubRepositoryDao("my-java-library-one", Map.of("spring", "3.0.0", "jacoco", "0.8.0")));
+    }
+
+    @Test
+    void testUpdatesStateWhenRun() {
+        GitHubRepository repo = new GitHubRepository("my-java-library-one", "trees.com", "main");
+        when(githubRepositoryServiceMock.listJavaRepositories()).thenReturn(List.of(
+                repo
+            )
+        );
+
+        when(githubRepositoryServiceMock.loadDependencies(repo)).thenReturn(
+            Map.of("spring", "3.0.0", "jacoco", "0.8.0")
+        );
+
+        fetchGithubRepositories.populateRepositoryCache();
+
+        verify(scheduledJobStateMock, times(1)).updateRunningState(eq(true));
+        verify(scheduledJobStateMock, times(1)).updateRunningState(eq(false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        booleans = {
+            true, false
+        }
+    )
+    void testIsRunningReturnsCorrectState(final boolean state) {
+        when(scheduledJobStateMock.isRunning()).thenReturn(state);
+
+        final boolean isRunning = fetchGithubRepositories.isRunning();
+
+        assertThat(isRunning).isEqualTo(state);
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/service/AppDataServiceTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/service/AppDataServiceTest.java
@@ -1,0 +1,125 @@
+package companieshouse.gov.uk.githubapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import companieshouse.gov.uk.githubapi.dao.GitHubRepoRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubAppData;
+import companieshouse.gov.uk.githubapi.model.GitHubRepositoryDao;
+
+@ExtendWith(MockitoExtension.class)
+public class AppDataServiceTest {
+
+    @Mock
+    private GitHubRepoRepository gitHubRepoRepositoryMock;
+
+    @InjectMocks
+    private AppDataService appDataService;
+
+    @Test
+    void testWhenCacheIsEmptyThenReturnsEmptyList() {
+        when(gitHubRepoRepositoryMock.findAll()).thenReturn(List.of());
+
+        final List<GitHubAppData> result = appDataService.loadAppData();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testWhenThereIsOneRepositoryWithDataThenReturnsListOfOneItem() {
+        when(gitHubRepoRepositoryMock.findAll()).thenReturn(List.of(
+            new GitHubRepositoryDao("repo", Map.of(
+                "spring-boot", "3.0.6",
+                "companies-house-parent", "3.1.2"
+            ))
+        ));
+
+        final List<GitHubAppData> result = appDataService.loadAppData();
+
+        assertThat(result).containsExactly(new GitHubAppData("repo", "repo", "3.0.6"));
+    }
+
+    @Test
+    void testWhenThereAreMultipleReposWithDataThenTheseAreReturned() {
+        final String repo1SBVersion = "3.0.6";
+        final String repo2SBVersion = "2.2.9";
+        final String repo3SBVersion = "1.2.6";
+
+        mongoContainsRepositories(
+            Map.of(
+                "repo1", Map.of(
+                    "spring-boot", repo1SBVersion,
+                    "companies-house-parent", "1.0,"
+                ),
+                "repo2",  Map.of(
+                    "spring-boot-parent", repo2SBVersion,
+                    "companies-house-parent", "1.0.0"
+                ),
+                "repo3", Map.of(
+                    "spring-boot", repo3SBVersion,
+                    "companies-house-parent", "1.0.0"
+                )
+            )
+        );
+
+        final List<GitHubAppData> result = appDataService.loadAppData();
+
+        assertThat(result)
+            .containsExactlyInAnyOrder(
+                new GitHubAppData("repo1", "repo1", repo1SBVersion),
+                new GitHubAppData("repo2", "repo2", repo2SBVersion),
+                new GitHubAppData("repo3", "repo3", repo3SBVersion)
+            );
+    }
+
+    @Test
+    void testWhenNoActualSpringBootVersionAndCanBeDerivedThenThisIsIndicatedInOutput() {
+        final String repo1SBVersion = "5.0.0";
+
+        mongoContainsRepositories(
+            Map.of(
+                "repo1", Map.of(
+                    "spring-framework", repo1SBVersion,
+                    "companies-house-parent", "1.0,"
+                ),
+                "repo2",  Map.of(
+                    "companies-house-parent", "1.0.0"
+                )
+            )
+        );
+
+        final List<GitHubAppData> result = appDataService.loadAppData();
+
+        assertThat(result)
+            .containsExactlyInAnyOrder(
+                new GitHubAppData("repo1", "repo1", "Uses native Spring version " + repo1SBVersion),
+                new GitHubAppData("repo2", "repo2", "Uses companies-house-parent pom (version: 1.0.0), no Spring version detected")
+            );
+    }
+
+    @Test
+    void testWhenCannotDetermineSpringVersionThenReturnsCorrectVersion() {
+        mongoContainsRepositories(Map.of(
+            "repo", Map.of("dependency", "1")
+        ));
+        
+        final List<GitHubAppData> result = appDataService.loadAppData();
+
+        assertThat(result).containsExactly(new GitHubAppData("repo", "repo", "No Spring detected"));
+    }
+
+    private void mongoContainsRepositories(final Map<String, Map<String, String>> repos) {
+        when(gitHubRepoRepositoryMock.findAll()).thenReturn(
+            repos.entrySet().stream().map(entry -> new GitHubRepositoryDao(entry.getKey(), entry.getValue())).toList()
+        );
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/service/GithubRepositoryServiceTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/service/GithubRepositoryServiceTest.java
@@ -1,0 +1,359 @@
+package companieshouse.gov.uk.githubapi.service;
+
+import static companieshouse.gov.uk.githubapi.util.ApiUtils.createLinks;
+import static companieshouse.gov.uk.githubapi.util.ApiUtils.makeResponseEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import companieshouse.gov.uk.githubapi.model.GitHubLeaf;
+import companieshouse.gov.uk.githubapi.model.GitHubRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubSearchResponse;
+import companieshouse.gov.uk.githubapi.model.GitHubTree;
+import companieshouse.gov.uk.githubapi.model.GitHubTreeResponse;
+import companieshouse.gov.uk.githubapi.util.GithubApi;
+import companieshouse.gov.uk.githubapi.util.QueryStringUtility;
+import companieshouse.gov.uk.githubapi.util.SequenceAnswer;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "github.pat=ghp_123456789012345",
+        "app.scheduling.enable=false"
+})
+public class GithubRepositoryServiceTest {
+
+    @Value("${github.pat}")
+    private String githubPat;
+
+    @MockBean
+    private RestOperations restOperationsMock;
+
+    @MockBean
+    private GithubApi githubApiMock;
+
+    @MockBean
+    private MavenDependenciesParsingService mvnDependenciesParsingServiceMock;
+
+    @Autowired
+    private GithubRepositoryService githubRepositoryService;
+
+    @Captor
+    private ArgumentCaptor<String> urlArgumentCaptor;
+
+    @Captor
+    private ArgumentCaptor<HttpEntity<?>> httpEntityArgumentCaptor;
+
+    @Value("classpath:demopom.xml")
+    private Resource demoPom;
+
+    @Test
+    void testListJavaRepositoriesLoadsSinglePageOfRepositories() {
+        final List<GitHubRepository> repositories = List.of(
+                new GitHubRepository("repo1", "tree1", "main"),
+                new GitHubRepository("repo3", "tree1", "main"),
+                new GitHubRepository("repo2", "tree1", "trunk"),
+                new GitHubRepository("repo4", "tree1", "master"));
+
+        final GitHubSearchResponse gitHubSearchResponse = new GitHubSearchResponse(
+                "1", 4, false, repositories);
+
+        final String expectedUrl = UriComponentsBuilder.fromHttpUrl("https://api.github.com/search/repositories")
+                .queryParam("q", "user:companieshouse+language:java")
+                .queryParam("page", 1)
+                .queryParam("per_page", 100).toUriString();
+        
+        when(githubApiMock.get(expectedUrl, GitHubSearchResponse.class))
+            .thenReturn(makeResponseEntity(gitHubSearchResponse, Optional.empty()));
+
+        githubRepositoryService.listJavaRepositories();
+
+        verify(githubApiMock, times(1)).get(expectedUrl, GitHubSearchResponse.class);
+    }
+
+    @Test
+    void testListJavaRepositoriesReturnsSinglePageOfRepositories() {
+        final List<GitHubRepository> repositories = List.of(
+                new GitHubRepository("repo1", "tree1", "main"),
+                new GitHubRepository("repo3", "tree1", "main"),
+                new GitHubRepository("repo2", "tree1", "trunk"),
+                new GitHubRepository("repo4", "tree1", "master"));
+
+        final GitHubSearchResponse gitHubSearchResponse = new GitHubSearchResponse(
+                "1", 4, false, repositories);
+        
+        when(githubApiMock.get(anyString(), eq(GitHubSearchResponse.class)))
+            .thenReturn(makeResponseEntity(gitHubSearchResponse, Optional.empty()));
+
+        final List<GitHubRepository> result = githubRepositoryService.listJavaRepositories();
+
+        assertThat(result).containsExactlyInAnyOrderElementsOf(repositories);
+    }
+
+    @Test
+    void testListJavaRepositoriesCanHandlePaginatedResponse() {
+        final int numberOfPages = 10;
+        final int pageSize = 100;
+
+        final List<List<GitHubRepository>> pagesOfRepos = ninePagesOfRepositories(numberOfPages, pageSize);
+
+        final List<ResponseEntity<GitHubSearchResponse>> responses = createResponses(numberOfPages, pageSize, pagesOfRepos);
+
+        final List<GitHubRepository> lastPage = createLastPageOfRepositories(24);
+
+        final ResponseEntity<GitHubSearchResponse> lastResponse = makeResponseEntity(
+                new GitHubSearchResponse(randomString(12), pageSize, false, lastPage),
+                Optional.of(createLinks(pageSize, numberOfPages, numberOfPages)));
+        
+        when(githubApiMock.get(anyString(), eq(GitHubSearchResponse.class)))
+            .thenAnswer(new SequenceAnswer<ResponseEntity<GitHubSearchResponse>>(responses.iterator(), lastResponse));
+
+        githubRepositoryService.listJavaRepositories();
+
+        verify(githubApiMock, times(10)).get(urlArgumentCaptor.capture(), eq(GitHubSearchResponse.class));
+
+        SoftAssertions.assertSoftly(softAssert -> {
+            final List<URI> requests = urlArgumentCaptor.getAllValues().stream().map(url -> {
+                    try {
+                            return new URI(url);
+                    } catch (final URISyntaxException e) {
+                            throw new RuntimeException(e);
+                    }
+            }).toList();
+
+            softAssert.assertThat(requests).anyMatch(request -> {
+                final Map<String, String> queryString = parseQueryString(request.getQuery());
+
+                return queryString.containsKey("page");
+            }).withFailMessage("Expected each request to have a page parameter");
+        
+            IntStream.range(0, 10)
+                .forEach(page -> {
+                    final URI request = requests.get(page);
+
+                    final Map<String, String> queryString = parseQueryString(request.getQuery());
+                    final Integer expectedPage = page + 1;
+
+                    softAssert.assertThat(queryString.get("page")).isEqualTo(expectedPage.toString());
+                });
+        });
+    }
+
+    @Test
+    void testListReposReturnsAllReposWhenResponseIsPaginated() {
+        final int numberOfPages = 10;
+        final int pageSize = 100;
+
+        final List<List<GitHubRepository>> pagesOfRepos = ninePagesOfRepositories(numberOfPages, pageSize);
+
+        final List<ResponseEntity<GitHubSearchResponse>> responses = createResponses(numberOfPages, pageSize, pagesOfRepos);
+
+        final List<GitHubRepository> lastPage = createLastPageOfRepositories(24);
+
+        final ResponseEntity<GitHubSearchResponse> lastResponse = makeResponseEntity(
+                new GitHubSearchResponse(randomString(12), pageSize, false, lastPage),
+                Optional.of(createLinks(pageSize, numberOfPages, numberOfPages)));
+        
+        final List<GitHubRepository> expectedRepositories = new ArrayList<>(lastPage);
+
+        expectedRepositories.addAll(
+            pagesOfRepos.stream()
+                .flatMap(page -> page.stream())
+                .toList()
+        );
+        
+        when(githubApiMock.get(anyString(), eq(GitHubSearchResponse.class)))
+            .thenAnswer(new SequenceAnswer<ResponseEntity<GitHubSearchResponse>>(responses.iterator(), lastResponse));
+
+        final List<GitHubRepository> gitHubRepositories = githubRepositoryService.listJavaRepositories();
+
+        assertThat(gitHubRepositories).containsExactlyInAnyOrderElementsOf(expectedRepositories);
+
+    }
+
+    @Test
+    void testLoadDependenciesLoadsTreesForThatRepository() {
+        final GitHubTreeResponse treeResponse = new GitHubTreeResponse(List.of());
+
+        when(githubApiMock.get(anyString(), any())).thenReturn(ResponseEntity.ok(treeResponse));
+
+        final GitHubRepository githubRepository = new GitHubRepository("awesomerepo1", "https://api.gh.com/trees/awesome1{/sha}", "main");
+
+        githubRepositoryService.loadDependencies(githubRepository);
+
+        verify(githubApiMock, times(1)).get("https://api.gh.com/trees/awesome1/main", GitHubTreeResponse.class);
+    }
+
+    @Test
+    void testLoadDependencesLoadsPomXmlWhenPresent() {
+        String url = "https://api.github.com/repos/companieshouse/github-query-app/git/blobs/b446a5e886ca4d885233484705873716c3f58356";
+        final GitHubTreeResponse treeResponse = new GitHubTreeResponse(List.of(
+            new GitHubTree("pom.xml", "100644", "blob", url, "b44fa5e886ca4d885233484705873716c3f58356"),
+            new GitHubTree("README.md", "100644", "blob", "https://blah/readme", "b44fa5e886ca4d885233484705873716c3f58356")
+        ));
+
+        when(githubApiMock.get(anyString(), eq(GitHubTreeResponse.class))).thenReturn(ResponseEntity.ok(treeResponse));
+        when(githubApiMock.get(anyString(), eq(GitHubLeaf.class))).thenReturn(ResponseEntity.ok(new GitHubLeaf("")));
+
+        final GitHubRepository githubRepository = new GitHubRepository("awesomerepo1", "https://api.gh.com/trees/awesome1{/sha}", "main");
+
+        githubRepositoryService.loadDependencies(githubRepository);
+
+        verify(githubApiMock, times(1)).get(url, GitHubLeaf.class);
+        verify(githubApiMock, never()).get(eq("https://blah/readme"), any());
+    }
+
+    @Test
+    void testLoadDependenciesReturnsDependenciesWithinPom() throws Exception {
+        String url = "https://api.github.com/repos/companieshouse/github-query-app/git/blobs/b446a5e886ca4d885233484705873716c3f58356";
+        final GitHubTreeResponse treeResponse = new GitHubTreeResponse(List.of(
+            new GitHubTree("pom.xml", "100644", "blob", url, "b44fa5e886ca4d885233484705873716c3f58356"),
+            new GitHubTree("README.md", "100644", "blob", "https://blah/readme", "b44fa5e886ca4d885233484705873716c3f58356")
+        ));
+
+        final GitHubRepository githubRepository = new GitHubRepository("awesomerepo1", "https://api.gh.com/trees/awesome1{/sha}", "main");
+        final Map<String, String> dependencyMap = Map.of("spring.boot", "3.0.0");
+        final String pom = new String(Files.readAllBytes(demoPom.getFile().toPath()));
+
+        when(githubApiMock.get(anyString(), eq(GitHubTreeResponse.class))).thenReturn(ResponseEntity.ok(treeResponse));
+
+        when(githubApiMock.get(anyString(), eq(GitHubLeaf.class))).thenReturn(ResponseEntity.ok(new GitHubLeaf(base64Encode(pom))));
+
+        when(mvnDependenciesParsingServiceMock.parseDependencies(anyString())).thenReturn(dependencyMap);
+
+        final Map<String, String> result = githubRepositoryService.loadDependencies(githubRepository);
+
+        assertThat(result).containsExactlyEntriesOf(dependencyMap);
+        verify(mvnDependenciesParsingServiceMock, times(1)).parseDependencies(pom);
+    }
+
+    @Test
+    void testLoadDependenciesCleansBase64BeforeLoad() throws Exception {
+        String url = "https://api.github.com/repos/companieshouse/github-query-app/git/blobs/b446a5e886ca4d885233484705873716c3f58356";
+        final GitHubTreeResponse treeResponse = new GitHubTreeResponse(List.of(
+            new GitHubTree("pom.xml", "100644", "blob", url, "b44fa5e886ca4d885233484705873716c3f58356"),
+            new GitHubTree("README.md", "100644", "blob", "https://blah/readme", "b44fa5e886ca4d885233484705873716c3f58356")
+        ));
+
+        final GitHubRepository githubRepository = new GitHubRepository("awesomerepo1", "https://api.gh.com/trees/awesome1{/sha}", "main");
+        final Map<String, String> dependencyMap = Map.of("spring.boot", "3.0.0");
+        final String pom = new String(Files.readAllBytes(demoPom.getFile().toPath()));
+
+        when(githubApiMock.get(anyString(), eq(GitHubTreeResponse.class))).thenReturn(ResponseEntity.ok(treeResponse));
+
+        when(githubApiMock.get(anyString(), eq(GitHubLeaf.class))).thenReturn(ResponseEntity.ok(new GitHubLeaf(base64Encode(pom) + "@£$%^&*()")));
+
+        when(mvnDependenciesParsingServiceMock.parseDependencies(anyString())).thenReturn(dependencyMap);
+
+        githubRepositoryService.loadDependencies(githubRepository);
+
+        verify(mvnDependenciesParsingServiceMock, times(1)).parseDependencies(pom);
+    }
+
+    @Test
+    void testLoadDependenciesReturnsEmptyMapWhenThereAreNoPomFiles() {
+        final GitHubTreeResponse treeResponse = new GitHubTreeResponse(List.of(
+            new GitHubTree("README.md", "100644", "blob", "https://blah/readme", "b44fa5e886ca4d885233484705873716c3f58356")
+        ));
+        final GitHubRepository githubRepository = new GitHubRepository("awesomerepo1", "https://api.gh.com/trees/awesome1{/sha}", "main");
+
+        when(githubApiMock.get(anyString(), eq(GitHubTreeResponse.class))).thenReturn(ResponseEntity.ok(treeResponse));
+
+        final Map<String, String> result = githubRepositoryService.loadDependencies(githubRepository);
+
+        assertThat(result).isEmpty();
+    }
+
+    private String base64Encode(final String toBeEncoded) {
+        final byte[] encodeBytes = toBeEncoded.getBytes(StandardCharsets.UTF_8);
+
+        return Base64.getEncoder().encodeToString(encodeBytes);
+    } 
+    
+    private List<GitHubRepository> createLastPageOfRepositories(final int pageSize) {
+        return IntStream.range(0, pageSize)
+                .boxed()
+                .map(repoNumber -> randomRepoName(repoNumber + 100))
+                .map(
+                        repoName -> new GitHubRepository(repoName, "https://github.com/" + repoName, "main"))
+                .toList();
+    }
+
+    private List<ResponseEntity<GitHubSearchResponse>> createResponses(final int numberOfPages, final int pageSize,
+            final List<List<GitHubRepository>> pagesOfRepos) {
+        return IntStream.range(0, pagesOfRepos.size())
+                .boxed()
+                .map(index -> makeResponseEntity(
+                        new GitHubSearchResponse(randomString(12), pageSize, false, pagesOfRepos.get(index)),
+                        Optional.of(
+                                createLinks(pageSize, index + 1, numberOfPages))))
+                .toList();
+    }
+
+    private List<List<GitHubRepository>> ninePagesOfRepositories(final int numberOfPages, final int pageSize) {
+        return IntStream.range(0, numberOfPages - 1)
+                .boxed()
+                .map(pageNumber -> IntStream
+                        .range(0, pageSize)
+                        .boxed()
+                        .map(repoNumber -> randomRepoName(repoNumber + 1))
+                        .map(
+                                repoName -> new GitHubRepository(repoName, "https://github.com/" + repoName, "main"))
+                        .toList()
+                )
+                .toList();
+    }
+
+    private String randomRepoName(final int counter) {
+        return "repo-" + counter + "-" + randomString(5);
+    }
+
+    private String randomString(final int length) {
+        final byte[] bytesArray = new byte[length];
+
+        new Random().nextBytes(bytesArray);
+
+        return new String(bytesArray, StandardCharsets.UTF_8);
+    }
+
+    private Map<String, String> parseQueryString(final String queryString) {
+        return QueryStringUtility.parseQueryString(queryString)
+            .entrySet()
+            .stream()
+            .map(entry -> Map.entry(entry.getKey(), entry.getValue().get(0)))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/service/MavenDependenciesParsingServiceTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/service/MavenDependenciesParsingServiceTest.java
@@ -1,0 +1,105 @@
+package companieshouse.gov.uk.githubapi.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.ResourceUtils;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import companieshouse.gov.uk.githubapi.service.mvn.ParseRule;
+
+@ExtendWith(MockitoExtension.class)
+public class MavenDependenciesParsingServiceTest {
+    
+
+    @Mock
+    private ParseRule ruleOne;
+
+    @Mock
+    private ParseRule ruleTwo;
+
+    @Mock
+    private DocumentBuilderFactory documentBuilderFactoryMock;
+
+    @Mock
+    private DocumentBuilder documentBuilderMock;
+
+    @Mock
+    private Document documentMock;
+
+    private MavenDependenciesParsingService mavenDependenciesParsingService;
+
+    private static String demoPom;
+
+    @BeforeAll
+    static void setupClass() throws Exception {
+        final File pomFile = ResourceUtils.getFile("classpath:demopom.xml");
+        
+        demoPom = new String(Files.readAllBytes(pomFile.toPath()));
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        mavenDependenciesParsingService = new MavenDependenciesParsingService(List.of(ruleOne, ruleTwo), documentBuilderFactoryMock);
+
+        when(documentBuilderFactoryMock.newDocumentBuilder()).thenReturn(documentBuilderMock);
+
+        // When running the error case it fails with unnecessary stubbings exception therefore this stub
+        // is not neccessary for that case but it is for all other tests
+        lenient().when(documentBuilderMock.parse(any(InputSource.class))).thenReturn(documentMock);
+    }
+
+    @Test
+    void testParseDependenciesParsesThePomBeforePassingToEachRule() {
+        mavenDependenciesParsingService.parseDependencies(demoPom);
+
+        verify(ruleOne, times(1)).run(documentMock);
+        verify(ruleTwo, times(1)).run(documentMock);
+    }
+
+    @Test
+    void testParseDependenciesReturnsAllDependenciesReturnedFromRules() {
+        Map<String, String> resultFromOne = Map.of(
+            "spring", "3.0.0",
+            "assertj", "2.4.1"
+        );
+        when(ruleOne.run(any())).thenReturn(resultFromOne);
+
+        Map<String, String> resultFromTwo = Map.of(
+            "junit", "4.0.0"
+        );
+        when(ruleTwo.run(any())).thenReturn(resultFromTwo);
+
+        final Map<String, String> result = mavenDependenciesParsingService.parseDependencies(demoPom);
+
+        assertThat(result).containsAllEntriesOf(resultFromOne).containsAllEntriesOf(resultFromTwo).hasSize(3);
+    }
+
+    @Test
+    void testParseDependenciesThrowsPoorlyFormattedExceptionWhenNotParsable() throws Exception {
+        when(documentBuilderMock.parse(any(InputSource.class))).thenThrow(new SAXException());
+
+        assertThatThrownBy(() -> mavenDependenciesParsingService.parseDependencies("<bad")).hasMessageContaining("Could not parse POM").hasCauseInstanceOf(SAXException.class);
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/service/mvn/DependencyManagementParseRuleTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/service/mvn/DependencyManagementParseRuleTest.java
@@ -1,0 +1,38 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import static companieshouse.gov.uk.githubapi.util.PomUtils.loadDemoPom;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+public class DependencyManagementParseRuleTest {
+
+    private final DependencyManagementParseRule dependencyManagementParseRule = new DependencyManagementParseRule();
+
+    @Test
+    void testReturnsEmptyMapWhenNoDependencyManagmentBlock() throws Exception {
+        final Document pom = loadDemoPom();
+
+        final Map<String, String> result = dependencyManagementParseRule.run(pom);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testReturnsMapOfVersionsWhenThereIsADependencyManagementBlock() throws Exception {
+        final Document pom = loadDemoPom("classpath:poms/dependency-management-pom.xml");
+
+        final Map<String, String> result = dependencyManagementParseRule.run(pom);
+
+        assertThat(result)
+            .containsExactlyInAnyOrderEntriesOf(Map.of(
+                "spring-boot", "3.1.0",
+                "another-one", "233.1.0"
+            )
+            );
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/service/mvn/ParentVersionParseRuleTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/service/mvn/ParentVersionParseRuleTest.java
@@ -1,0 +1,47 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static companieshouse.gov.uk.githubapi.util.PomUtils.loadDemoPom;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.w3c.dom.Document;
+
+public class ParentVersionParseRuleTest {
+
+    private final ParentVersionParseRule parentVersionParseRule = new ParentVersionParseRule();
+
+    @Test
+    void testWhenParentIsNotCompaniesHouseParentThenAddsAsADependency() throws Exception {
+        final Document pom = loadDemoPom();
+
+        final Map<String, String> result = parentVersionParseRule.run(pom);
+
+        assertThat(result).containsEntry("spring-boot-starter-parent", "3.0.6").hasSize(1);
+    }
+
+    @Test
+    void testWhenParentIsCompaniesHouseParentThenReturnsEmptyMap() throws Exception {
+        final Document pom = loadDemoPom("classpath:poms/ch-parent-pom.xml");
+
+        final Map<String, String> result = parentVersionParseRule.run(pom);
+
+        assertThat(result).containsOnly(Map.entry("companies-house-parent", "1.3.1"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "classpath:poms/erroneous/parent-empty-pom.xml",
+        "classpath:poms/erroneous/parent-no-groupid-pom.xml",
+        "classpath:poms/erroneous/parent-no-artifactid-pom.xml"
+    })
+    void testWhenParentIsInvalidThenThrowsPoorlyFormattedPomException(String string) throws Exception {
+        final Document erroneousPom = loadDemoPom(string);
+
+        assertThatThrownBy(() -> parentVersionParseRule.run(erroneousPom)).hasMessageMatching("Dependency missing required parameter: (artifactId|groupId)");
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/service/mvn/PropertiesParseRuleTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/service/mvn/PropertiesParseRuleTest.java
@@ -1,0 +1,53 @@
+package companieshouse.gov.uk.githubapi.service.mvn;
+
+import static companieshouse.gov.uk.githubapi.util.PomUtils.loadDemoPom;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+public class PropertiesParseRuleTest {
+    
+
+    private static Document demoPom;
+
+    private final PropertiesParseRule propertiesParseRule = new PropertiesParseRule();
+
+    @BeforeAll
+    static void setupClass() throws Exception {
+        demoPom = loadDemoPom();
+    }
+
+    @Test
+    void testLoadsVersionsFromPropertiesSectionOfPom() {
+        final Map<String, String> result = propertiesParseRule.run(demoPom);
+
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+            "java", "17",
+            "http-client", "5.2.1",
+            "apache-commons-lang3", "3.12.0"
+        ));
+    }
+
+    @Test
+    void testWhenPropertiesEmptyThenReturnsEmptyMap() throws Exception {
+        final Document noProperties = loadDemoPom("classpath:poms/no-properties-pom.xml");
+
+        final Map<String, String> result = propertiesParseRule.run(noProperties);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testWhenNoPropertiesTagThenReturnsEmptyMap() throws Exception {
+        final Document noProperties = loadDemoPom("classpath:poms/no-properties-tag-pom.xml");
+
+        final Map<String, String> result = propertiesParseRule.run(noProperties);
+
+        assertThat(result).isEmpty();
+
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/util/ApiUtils.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/util/ApiUtils.java
@@ -1,0 +1,58 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity.BodyBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class ApiUtils {
+    
+    private ApiUtils() {}
+
+    public static <T> ResponseEntity<T> makeResponseEntity(
+        final T response,
+        final Optional<String> linkHeaders
+    ) {
+        final BodyBuilder builder = ResponseEntity.ok();
+
+        linkHeaders.ifPresent(headers -> builder.header("Link", headers));
+
+        return builder.body(response);
+    }
+
+    public static String createLinks(final int pageSize, final int page, final int numberOfPages) {
+        final String[] linkTypes = { "prev", "next", "last", "first" };
+
+        return Arrays.stream(linkTypes)
+                .map(linkRelationship -> createLink(pageSize, page, numberOfPages, linkRelationship))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.joining(", "));
+    }
+
+    private static Optional<String> createLink(final int pageSize, final int page, final int numberOfPages, final String relationship) {
+        return switch (relationship) {
+            case "prev" -> page > 1 ? Optional.of(link(page - 1, relationship)) : Optional.empty();
+            case "next" -> page < numberOfPages ? Optional.of(link(page+1, relationship)) : Optional.empty();
+            case "last" -> Optional.empty();
+            default -> Optional.of(link(1, relationship));
+        };
+    }
+
+    private static String link(final int page, final String relationship) {
+        final StringBuilder linkBuilder = new StringBuilder();
+
+        final String linkUrl = UriComponentsBuilder.fromHttpUrl("https://api.gitub.com/search/repositories")
+                .queryParam("page", page)
+                .toUriString();
+
+        return linkBuilder.append("<")
+                .append(linkUrl)
+                .append(">; rel=\"")
+                .append(relationship)
+                .append("\"").toString();
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/util/GithubApiTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/util/GithubApiTest.java
@@ -1,0 +1,136 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import static companieshouse.gov.uk.githubapi.util.ApiUtils.makeResponseEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import companieshouse.gov.uk.githubapi.model.GitHubRepository;
+import companieshouse.gov.uk.githubapi.model.GitHubSearchResponse;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "github.pat=ghp_123456789012345",
+        "app.scheduling.enable=false",
+        "app.retry.enable=true",
+        "app.retry.delay=10",
+        "app.retry.multiplier=2"
+})
+public class GithubApiTest {
+    
+
+    @Value("${github.pat}")
+    private String githubPat;
+
+    @MockBean
+    private RestOperations restOperationsMock;
+
+    @Autowired
+    private GithubApi githubApi;
+
+    @Captor
+    private ArgumentCaptor<HttpEntity<?>> httpEntityArgumentCaptor;
+    
+    @Test
+    void testListJavaRepositoriesLoadsSinglePageOfRepositories() {
+        final List<GitHubRepository> repositories = List.of(
+                new GitHubRepository("repo1", "tree1", "main"),
+                new GitHubRepository("repo3", "tree1", "main"),
+                new GitHubRepository("repo2", "tree1", "trunk"),
+                new GitHubRepository("repo4", "tree1", "master"));
+
+        final GitHubSearchResponse gitHubSearchResponse = new GitHubSearchResponse(
+                "1", 4, false, repositories);
+
+        final String expectedUrl = UriComponentsBuilder.fromHttpUrl("https://api.github.com/search/repositories")
+                .queryParam("q", "user:companieshouse+language:java")
+                .queryParam("page", 1)
+                .queryParam("per_page", 100).toUriString();
+        
+        when(restOperationsMock.exchange(anyString(), eq(HttpMethod.GET), any(), eq(GitHubSearchResponse.class)))
+                .thenReturn(makeResponseEntity(gitHubSearchResponse, Optional.empty()));
+        
+        githubApi.get(expectedUrl, GitHubSearchResponse.class);
+
+        verify(restOperationsMock, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.GET), httpEntityArgumentCaptor.capture(), eq(GitHubSearchResponse.class));
+
+        final HttpEntity<?> httpEntity = httpEntityArgumentCaptor.getValue();
+        assertThat(httpEntity.getHeaders().get("Authorization")).isNotNull().containsOnly("Bearer " + githubPat);
+    }
+
+    @Test
+    void testGetReturnsBody() {
+        final List<GitHubRepository> repositories = List.of(
+                new GitHubRepository("repo1", "tree1", "main"),
+                new GitHubRepository("repo3", "tree1", "main"),
+                new GitHubRepository("repo2", "tree1", "trunk"),
+                new GitHubRepository("repo4", "tree1", "master"));
+
+        final GitHubSearchResponse gitHubSearchResponse = new GitHubSearchResponse(
+                "1", 4, false, repositories);
+
+        when(restOperationsMock.exchange(
+                anyString(),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(GitHubSearchResponse.class)
+        )).thenReturn(makeResponseEntity(gitHubSearchResponse, Optional.empty()));
+
+        final ResponseEntity<GitHubSearchResponse> result = githubApi.get("https://api.github.com/repositories/search", GitHubSearchResponse.class);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+        assertThat(result.getBody().repositories()).containsExactlyInAnyOrderElementsOf(repositories);
+    }
+
+    @Test
+    void testGetThrowsGithubApiCallErrorExceptionWhenHitRateLimitExhausted() {
+        when(restOperationsMock.exchange(
+            anyString(),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(GitHubSearchResponse.class)
+        )).thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(429)));
+
+        assertThatThrownBy(() -> githubApi.get("https://api.github.com/repositories/search", GitHubSearchResponse.class))
+                .hasCauseInstanceOf(HttpClientErrorException.class);
+    }
+
+    @Test
+    void testGetRetriesAfterFails() {
+        when(restOperationsMock.exchange(
+            anyString(),
+            eq(HttpMethod.GET),
+            any(HttpEntity.class),
+            eq(String.class)
+        )).thenThrow(new HttpClientErrorException(HttpStatusCode.valueOf(429))).thenReturn(ResponseEntity.ok().body("Hello"));
+
+        final ResponseEntity<String> result = githubApi.get("https://api.github.com/search", String.class);
+
+        assertThat(result.getBody()).isEqualTo("Hello");
+    }
+
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/util/NameUtilsTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/util/NameUtilsTest.java
@@ -1,0 +1,39 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static companieshouse.gov.uk.githubapi.util.NameUtils.normaliseName;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class NameUtilsTest {
+    @ParameterizedTest
+    @CsvSource({
+        "spring-boot-parent,spring-boot-parent",
+        "spring-boot,spring-boot",
+        "companieshouse-parent,companieshouse-parent",
+        "spring-boot-dependencies,spring-boot",
+        "java,java",
+        "http-client,http-client"
+    })
+    void testNormaliseNameWithNoSeparatorUsesHyphen(final String input, final String expected) {
+        final String normalisedName = normaliseName(input);
+
+        assertThat(normalisedName).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "spring.boot.version,.,spring-boot",
+        "java,.,java",
+        "http.client.version,.,http-client",
+        "http=client=version,=,http-client",
+        "http client,=,http-client",
+        "commons-lang3.version,.,commons-lang3"
+    })
+    void testNormaliseNameWithSeparator(final String input, final String separator, final String expected) {
+        final String normalisedName = normaliseName(input, separator);
+
+        assertThat(normalisedName).isEqualTo(expected);
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/util/PomUtils.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/util/PomUtils.java
@@ -1,0 +1,24 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.springframework.util.ResourceUtils;
+import org.w3c.dom.Document;
+
+public class PomUtils {
+    
+
+    private PomUtils() {}
+ 
+    public static Document loadDemoPom() throws Exception {
+        return loadDemoPom("classpath:demopom.xml");
+    }
+
+    public static Document loadDemoPom(final String resourcePath) throws Exception {
+        final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+
+        return documentBuilder.parse(ResourceUtils.getFile(resourcePath));
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/util/QueryStringUtilityTest.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/util/QueryStringUtilityTest.java
@@ -1,0 +1,24 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import org.junit.jupiter.api.Test;
+
+import static companieshouse.gov.uk.githubapi.util.QueryStringUtility.parseQueryString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+public class QueryStringUtilityTest {
+    @Test
+    void testParseQueryString() {
+        final String query = "one=two&three=four&one=five&six=1000";
+        final Map<String, List<String>> expected = Map.of(
+            "one", List.of("two", "five"),
+            "three", List.of("four"),
+            "six", List.of("1000")
+        );
+
+        assertThat(parseQueryString(query))
+            .containsAllEntriesOf(expected);
+    }
+}

--- a/src/test/java/companieshouse/gov/uk/githubapi/util/SequenceAnswer.java
+++ b/src/test/java/companieshouse/gov/uk/githubapi/util/SequenceAnswer.java
@@ -1,0 +1,28 @@
+package companieshouse.gov.uk.githubapi.util;
+
+import java.util.Iterator;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class SequenceAnswer<T> implements Answer<T> {
+
+    private final Iterator<T> resultIterator;
+    private final T last;
+
+    public SequenceAnswer(final Iterator<T> resultIterator, final T last) {
+        this.resultIterator = resultIterator;
+        this.last = last;
+    }
+
+
+
+    @Override
+    public T answer(InvocationOnMock invocation) throws Throwable {
+        if (resultIterator.hasNext()) {
+            return resultIterator.next();
+        }
+        return last;
+    }
+    
+}

--- a/src/test/resources/demopom.xml
+++ b/src/test/resources/demopom.xml
@@ -52,26 +52,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/ch-parent-pom.xml
+++ b/src/test/resources/poms/ch-parent-pom.xml
@@ -3,10 +3,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<groupId>uk.gov.companieshouse</groupId>
+		<artifactId>companies-house-parent</artifactId>
+		<version>1.3.1</version> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>companieshouse.gov.uk</groupId>
 	<artifactId>github-query-api</artifactId>
@@ -52,26 +51,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/dependency-management-pom.xml
+++ b/src/test/resources/poms/dependency-management-pom.xml
@@ -14,10 +14,26 @@
 	<name>github-query-api</name>
 	<description>Github API call</description>
 	<properties>
-		<java.version>17</java.version>
-		<http.client.version>5.2.1</http.client.version>
-		<apache.commons-lang3.version>3.12.0</apache.commons-lang3.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>3.1.0</version>
+				<packaging>pom</packaging>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.example</groupId>
+				<artifactId>another-one</artifactId>
+				<version>233.1.0</version>
+				<packaging>pom</packaging>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
@@ -52,26 +68,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/erroneous/parent-empty-pom.xml
+++ b/src/test/resources/poms/erroneous/parent-empty-pom.xml
@@ -3,10 +3,6 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>companieshouse.gov.uk</groupId>
 	<artifactId>github-query-api</artifactId>
@@ -14,9 +10,6 @@
 	<name>github-query-api</name>
 	<description>Github API call</description>
 	<properties>
-		<java.version>17</java.version>
-		<http.client.version>5.2.1</http.client.version>
-		<apache.commons-lang3.version>3.12.0</apache.commons-lang3.version>
 	</properties>
 
 	<dependencies>
@@ -52,26 +45,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/erroneous/parent-no-artifactid-pom.xml
+++ b/src/test/resources/poms/erroneous/parent-no-artifactid-pom.xml
@@ -4,7 +4,6 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
@@ -14,9 +13,6 @@
 	<name>github-query-api</name>
 	<description>Github API call</description>
 	<properties>
-		<java.version>17</java.version>
-		<http.client.version>5.2.1</http.client.version>
-		<apache.commons-lang3.version>3.12.0</apache.commons-lang3.version>
 	</properties>
 
 	<dependencies>
@@ -52,26 +48,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/erroneous/parent-no-groupid-pom.xml
+++ b/src/test/resources/poms/erroneous/parent-no-groupid-pom.xml
@@ -3,8 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
+		<artifactId>org.springframework.boot</artifactId>
 		<version>3.0.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
@@ -14,9 +13,6 @@
 	<name>github-query-api</name>
 	<description>Github API call</description>
 	<properties>
-		<java.version>17</java.version>
-		<http.client.version>5.2.1</http.client.version>
-		<apache.commons-lang3.version>3.12.0</apache.commons-lang3.version>
 	</properties>
 
 	<dependencies>
@@ -52,26 +48,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/no-properties-pom.xml
+++ b/src/test/resources/poms/no-properties-pom.xml
@@ -14,9 +14,6 @@
 	<name>github-query-api</name>
 	<description>Github API call</description>
 	<properties>
-		<java.version>17</java.version>
-		<http.client.version>5.2.1</http.client.version>
-		<apache.commons-lang3.version>3.12.0</apache.commons-lang3.version>
 	</properties>
 
 	<dependencies>
@@ -52,26 +49,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/resources/poms/no-properties-tag-pom.xml
+++ b/src/test/resources/poms/no-properties-tag-pom.xml
@@ -13,11 +13,6 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>github-query-api</name>
 	<description>Github API call</description>
-	<properties>
-		<java.version>17</java.version>
-		<http.client.version>5.2.1</http.client.version>
-		<apache.commons-lang3.version>3.12.0</apache.commons-lang3.version>
-	</properties>
 
 	<dependencies>
 		<dependency>
@@ -52,26 +47,15 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${apache.commons-lang3.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <version>4.4.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Other changes:

* Use  `record` classes to reduce boiler plate
* Add some testing around loading of data from Github
* Change beans to `RestOperations` rather than `RestTemplate` (program to interface)